### PR TITLE
Added pmpro_before_send_to_gourl action before redirecting

### DIFF
--- a/gourl_paidmembershipspro.php
+++ b/gourl_paidmembershipspro.php
@@ -539,6 +539,8 @@ if (!function_exists('gourl_pmp_gateway_load'))
 				$_SESSION['gourl_pmp_orderid'] = $order->id; 
 				$_SESSION['gourl_pmp_orderdt'] = ($enddate == "NULL") ? __('NO EXPIRY', GOURLPMP) : date("d M Y", $new_startdate) . " - " . date("d M Y", strtotime(trim($enddate, "'")));
 
+				do_action( 'pmpro_before_send_to_gourl', $user_id, $morder );
+
 				wp_redirect(pmpro_url("confirmation"));
 				die();
 		


### PR DESCRIPTION
This hook is similar to others we have for PayPal Standard and 2Checkout/etc.

The hook can be used to perform actions after the WP user has been created but before the user is redirected away from the checkout page. For example, the register helper plugin will use it to save extra user meta to the user.